### PR TITLE
Prevent showing a "flash" up previous upcoming content

### DIFF
--- a/src/Upcoming/index.js
+++ b/src/Upcoming/index.js
@@ -6,8 +6,13 @@ export default function Upcoming() {
   const [newest] = Object.keys(data);
   const d = newest.split(' ')[0];
   const isUpcoming = new Date(d) > Date.now();
+  const isPreRendering =
+    typeof navigator === 'object'
+      ? navigator.userAgent.includes('ReactSnap')
+      : false;
 
-  if (!isUpcoming) {
+  // Prevent a "flash" of upcoming content by never rendering it for our pre-rendered HTML.
+  if (!isUpcoming || isPreRendering) {
     return null;
   }
 


### PR DESCRIPTION
When the last build ran, there was an upcoming event. This meant the `<Upcoming/>` component was rendered into the static/pre-rendered HTML. However, since that event is now in the past, once React mounted, the `<Upcoming/>` component had nothing to show (and simply did `return null`). This created a "flash" of upcoming content.

By _never_ including the `<Upcoming/>` component in pre-rendered builds, we avoid the flash permanently. Instead, the opposite will happen (which is _much_ less intrusive/confusing IMO): after React mounts/the page's JavaScript runs, the `<Upcoming/>` content will appear.

While user-agent sniffing is generally frowned upon, this [is the recommendation by the folks behind `react-snap` for this sort of thing](https://github.com/stereobooster/react-snap#useragent).